### PR TITLE
doctest fix

### DIFF
--- a/src/Poker/Range.hs
+++ b/src/Poker/Range.hs
@@ -22,6 +22,11 @@ import           Data.Text.Prettyprint.Doc      ( (<+>)
 #endif
 import Poker.Cards
 
+-- $setup
+-- >>> :set -XTypeApplications
+-- >>> import Poker
+-- >>> import Poker.Range
+
 -- | A frequency is an unevaluated ratio that indicates how often a decision was
 -- made. For example, the value Freq (12, 34) indicates that out of the 34
 -- people who faced this decision, 12 chose to make this decision.
@@ -40,11 +45,10 @@ instance Semigroup Freq where
 -- >>> mempty @(Range Hand Freq)
 -- Range {_range = fromList []}
 -- >>> import qualified Data.Text as T
--- >>> import Poker.ParsePretty (unsafeParsePretty)
--- >>> let left = fromList [(unsafeParsePretty @ShapedHand $ T.pack "55p", Freq (1, 3))]
--- >>> let right = fromList [(unsafeParsePretty $ T.pack"55p", Freq (10, 32))]
+-- >>> let left = fromList [(unsafeParsePretty @ShapedHand $ T.pack "55p", Freq 1 3)]
+-- >>> let right = fromList [(unsafeParsePretty $ T.pack"55p", Freq 10 32)]
 -- >>> left <> right
--- Range {_range = fromList [(Pair Five,Freq (11,35))]}
+-- Range {_range = fromList [(MkPair Five,Freq 11 35)]}
 newtype Range a b
   = Range
       {_range :: Map a b}


### PR DESCRIPTION
This allows the repo to pass `cabal-docspec`.

cabal-docspec is a lot stricter than normal doctesting. It doesn't allow you to use internal modules, for example, so you can't say `import Poker.ParsePretty` in this instance. It also has no access to the file, so it doesn't pick up pragmas that are there.  I really like the strictness as the doctest forms a pretty solid representation of how best to run the module for the user.