### PR TITLE
Rename (Shaped)Hand -> (Shaped)Hole

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -15,7 +15,7 @@ As a base library, a general development goal is to keep everything neat, tidy, 
 To help with this we recommend a few external tools:
 
 - [tasty-discover](https://hackage.haskell.org/package/tasty-discover) as a runner for the [tasty](https://hackage.haskell.org/package/tasty) test framework.
-- [ormulo](https://hackage.haskell.org/package/ormolu) to automate code formatting consistency.
+- [ormolu](https://hackage.haskell.org/package/ormolu) to automate code formatting consistency.
 - [hlint](https://hackage.haskell.org/package/hlint) for code linting, and
 - [cabal-docspec](https://github.com/phadej/cabal-extras/blob/master/cabal-docspec/MANUAL.md) as a doctest runner.
 

--- a/src/Poker/Cards.hs
+++ b/src/Poker/Cards.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
 
 module Poker.Cards
   ( Rank (..),
@@ -11,12 +10,12 @@ module Poker.Cards
     suitFromUnicode,
     Card (..),
     allCards,
-    Hand (..),
-    pattern Hand,
-    mkHand,
-    unsafeMkHand,
-    allHands,
-    ShapedHand (..),
+    Hole (..),
+    pattern Hole,
+    mkHole,
+    unsafeMkHole,
+    allHoles,
+    ShapedHole (..),
     pattern Offsuit,
     pattern Pair,
     pattern Suited,
@@ -25,13 +24,13 @@ module Poker.Cards
     mkSuited,
     unsafeMkSuited,
     unsafeMkOffsuit,
-    listShapedHands,
-    handToShaped,
+    listShapedHoles,
+    holeToShaped,
     Deck,
     pattern Deck,
     freshDeck,
     unsafeMkDeck,
-    shapedHandToHands,
+    shapedHoleToHoles,
   )
 where
 
@@ -198,83 +197,83 @@ instance Bounded Card where
 allCards :: [Card]
 allCards = liftM2 Card allRanks allSuits
 
--- | 'Hand' represents a player's hole cards in a game of Texas Hold\'Em
-data Hand = MkHand !Card !Card
+-- | 'Hole' represents a player's hole cards in a game of Texas Hold\'Em
+data Hole = MkHole !Card !Card
   deriving (Eq, Ord, Show)
 
 -- TODO tests
-instance IsString Hand where
+instance IsString Hole where
   fromString = fromJust . parsePretty . T.pack
 
-{-# COMPLETE Hand #-}
+{-# COMPLETE Hole #-}
 
-pattern Hand :: Card -> Card -> Hand
-pattern Hand c1 c2 <- MkHand c1 c2
+pattern Hole :: Card -> Card -> Hole
+pattern Hole c1 c2 <- MkHole c1 c2
 
--- | Returns a 'Hand' if the incoming 'Card's are unique, else 'Nothing'.
--- Note that the internal representation of 'Hand' is normalised:
+-- | Returns a 'Hole' if the incoming 'Card's are unique, else 'Nothing'.
+-- Note that the internal representation of 'Hole' is normalised:
 --
 -- prop> mkHand c1 c2 == mkHand c2 c1
-mkHand :: Card -> Card -> Maybe Hand
-mkHand c1 c2
-  | c1 /= c2 = Just $ if c2 > c1 then MkHand c2 c1 else MkHand c1 c2
+mkHole :: Card -> Card -> Maybe Hole
+mkHole c1 c2
+  | c1 /= c2 = Just $ if c2 > c1 then MkHole c2 c1 else MkHole c1 c2
   | otherwise = Nothing
 
--- | Unsafely creates a new 'Hand'. The two input 'Card's are expected to be
+-- | Unsafely creates a new 'Hole'. The two input 'Card's are expected to be
 -- unique, and the first 'Card' should be less than the second 'Card' (as defined by
--- 'Ord'). See 'mkHand' for a safe way to create 'Hand's.
-unsafeMkHand :: Card -> Card -> Hand
-unsafeMkHand c1 c2 =
-  fromMaybe (terror $ "Cannot form a Hand from " <> prettyText (c1, c2)) $
-    mkHand c1 c2
+-- 'Ord'). See 'mkHole' for a safe way to create 'Hole's.
+unsafeMkHole :: Card -> Card -> Hole
+unsafeMkHole c1 c2 =
+  fromMaybe (terror $ "Cannot form a Hole from " <> prettyText (c1, c2)) $
+    mkHole c1 c2
 
--- | All possible Hold'Em poker 'Hand's
+-- | All possible Hold'Em poker 'Hole's
 --
 -- TODO add tests
-allHands :: [Hand]
-allHands = reverse $ do
+allHoles :: [Hole]
+allHoles = reverse $ do
   r1 <- enumerate
   r2 <- enumFrom r1
   (s1, s2) <-
     if r1 == r2
       then [(s1, s2) | s1 <- enumerate, s2 <- drop 1 (enumFrom s1)]
       else liftM2 (,) enumerate enumerate
-  pure $ unsafeMkHand (Card r1 s1) (Card r2 s2)
+  pure $ unsafeMkHole (Card r1 s1) (Card r2 s2)
 
-instance Enum Hand where
+instance Enum Hole where
   toEnum num =
-    fromMaybe (error $ "Invalid Hand enum: " <> show num)
+    fromMaybe (error $ "Invalid Hole enum: " <> show num)
       . flip
         Data.IntMap.Strict.lookup
-        (Data.IntMap.Strict.fromList $ zip [1 ..] allHands)
+        (Data.IntMap.Strict.fromList $ zip [1 ..] allHoles)
       $ num
   fromEnum =
     fromJust
       . flip
         Data.Map.Strict.lookup
-        (Data.Map.Strict.fromList $ zip allHands [1 ..])
+        (Data.Map.Strict.fromList $ zip allHoles [1 ..])
 
-instance Bounded Hand where
-  minBound = head allHands
-  maxBound = last allHands
+instance Bounded Hole where
+  minBound = head allHoles
+  maxBound = last allHoles
 
--- >>> pretty $ Hand (Card Ace Heart) (Card King Spade)
+-- >>> pretty $ Hole (Card Ace Heart) (Card King Spade)
 -- AhKs
-instance Pretty Hand where
-  pretty (Hand c1 c2) = pretty c1 <> pretty c2
+instance Pretty Hole where
+  pretty (Hole c1 c2) = pretty c1 <> pretty c2
 
--- >>> parsePretty @Hand "AhKs"
--- Just (Hand (Card {rank = Ace, suit = Heart}) (Card {rank = King, suit = Spade}))
-instance ParsePretty Hand where
-  parsePrettyP = label "Hand" $ do
+-- >>> parsePretty @Hole "AhKs"
+-- Just (Hole (Card {rank = Ace, suit = Heart}) (Card {rank = King, suit = Spade}))
+instance ParsePretty Hole where
+  parsePrettyP = label "Hole" $ do
     c1 <- parsePrettyP
     c2 <- parsePrettyP
     maybe (tfailure $ "Invalid card: " <> prettyText (c1, c2)) pure $
-      mkHand c1 c2
+      mkHole c1 c2
 
 -- |
--- A 'ShapedHand' is the 'Suit'-normalised representation of a
--- poker 'Hand'. For example, the 'Hand' "King of Diamonds, 5 of Hearts" is often referred
+-- A 'ShapedHole' is the 'Suit'-normalised representation of a
+-- poker 'Hole'. For example, the 'Hole' "King of Diamonds, 5 of Hearts" is often referred
 -- to as "King-5 offsuit".
 --
 -- >>> pretty $ mkPair Two
@@ -285,53 +284,53 @@ instance ParsePretty Hand where
 -- suited : 24s
 --
 -- >>> import Poker.ParsePretty
--- >>> parsePretty @ShapedHand "22p"
+-- >>> parsePretty @ShapedHole "22p"
 -- Just (MkPair Two)
--- >>> parsePretty @ShapedHand "24o"
+-- >>> parsePretty @ShapedHole "24o"
 -- Just (MkOffsuit Four Two)
--- >>> parsePretty @ShapedHand "24s"
+-- >>> parsePretty @ShapedHole "24s"
 -- Just (MkSuited Four Two)
 --
 -- TODO Make patterns uni-directional (don't expose constructors)
-data ShapedHand = MkPair !Rank | MkOffsuit !Rank !Rank | MkSuited !Rank !Rank
+data ShapedHole = MkPair !Rank | MkOffsuit !Rank !Rank | MkSuited !Rank !Rank
   deriving (Eq, Ord, Show, Read)
 
 {-# COMPLETE Pair, Offsuit, Suited #-}
 
-pattern Pair :: Rank -> ShapedHand
+pattern Pair :: Rank -> ShapedHole
 pattern Pair r <- MkPair r
 
-pattern Offsuit :: Rank -> Rank -> ShapedHand
+pattern Offsuit :: Rank -> Rank -> ShapedHole
 pattern Offsuit r1 r2 <- MkOffsuit r1 r2
 
-pattern Suited :: Rank -> Rank -> ShapedHand
+pattern Suited :: Rank -> Rank -> ShapedHole
 pattern Suited r1 r2 <- MkSuited r1 r2
 
-mkPair :: Rank -> ShapedHand
+mkPair :: Rank -> ShapedHole
 mkPair = MkPair
 
-mkSuited :: Rank -> Rank -> Maybe ShapedHand
+mkSuited :: Rank -> Rank -> Maybe ShapedHole
 mkSuited r1 r2
   | r1 /= r2 = Just $ if r1 > r2 then MkSuited r1 r2 else MkSuited r2 r1
   | otherwise = Nothing
 
-unsafeMkSuited :: Rank -> Rank -> ShapedHand
+unsafeMkSuited :: Rank -> Rank -> ShapedHole
 unsafeMkSuited r1 r2 =
   fromMaybe (terror $ "Invalid Suited hand: " <> prettyText (r1, r2)) $
     mkSuited r1 r2
 
-mkOffsuit :: Rank -> Rank -> Maybe ShapedHand
+mkOffsuit :: Rank -> Rank -> Maybe ShapedHole
 mkOffsuit r1 r2
   | r1 /= r2 = Just $ if r1 > r2 then MkOffsuit r1 r2 else MkOffsuit r2 r1
   | otherwise = Nothing
 
-unsafeMkOffsuit :: HasCallStack => Rank -> Rank -> ShapedHand
+unsafeMkOffsuit :: HasCallStack => Rank -> Rank -> ShapedHole
 unsafeMkOffsuit r1 r2 =
   fromMaybe (terror $ "Cannot form offsuit hand from: " <> prettyText (r1, r2)) $
     mkOffsuit r1 r2
 
-listShapedHands :: [ShapedHand]
-listShapedHands = reverse $ do
+listShapedHoles :: [ShapedHole]
+listShapedHoles = reverse $ do
   rank1 <- enumerate
   rank2 <- enumerate
   return $ case compare rank1 rank2 of
@@ -340,57 +339,57 @@ listShapedHands = reverse $ do
     LT -> unsafeMkOffsuit rank1 rank2
 
 -- | >>> import Poker.ParsePretty
--- >>> pretty . shapedHandToHands $ unsafeParsePretty "55p"
+-- >>> pretty . shapedHoleToHoles $ unsafeParsePretty "55p"
 -- [5d5c, 5h5c, 5s5c, 5h5d, 5s5d, 5s5h]
--- >>> pretty . shapedHandToHands $ unsafeParsePretty "97o"
+-- >>> pretty . shapedHoleToHoles $ unsafeParsePretty "97o"
 -- [9c7d, 9c7h, 9c7s, 9d7c, 9d7h, 9d7s, 9h7c, 9h7d, 9h7s, 9s7c, 9s7d, 9s7h]
--- >>> pretty . shapedHandToHands $ unsafeParsePretty "QTs"
+-- >>> pretty . shapedHoleToHoles $ unsafeParsePretty "QTs"
 -- [QcTc, QdTd, QhTh, QsTs]
-shapedHandToHands :: ShapedHand -> [Hand]
-shapedHandToHands = \case
+shapedHoleToHoles :: ShapedHole -> [Hole]
+shapedHoleToHoles = \case
   Pair r -> do
     s1 <- enumerate
     s2 <- drop (fromEnum s1 + 1) enumerate
-    pure $ unsafeMkHand (Card r s1) (Card r s2)
+    pure $ unsafeMkHole (Card r s1) (Card r s2)
   Offsuit r1 r2 -> do
     s1 <- enumerate
     s2 <- filter (s1 /=) enumerate
-    pure $ unsafeMkHand (Card r1 s1) (Card r2 s2)
+    pure $ unsafeMkHole (Card r1 s1) (Card r2 s2)
   Suited r1 r2 -> do
     s <- enumerate
-    pure $ unsafeMkHand (Card r1 s) (Card r2 s)
+    pure $ unsafeMkHole (Card r1 s) (Card r2 s)
 
 -- TODO needs tests
-handToShaped :: Hand -> ShapedHand
-handToShaped (Hand (Card r1 s1) (Card r2 s2))
+holeToShaped :: Hole -> ShapedHole
+holeToShaped (Hole (Card r1 s1) (Card r2 s2))
   | r1 == r2 = mkPair r1
   | s1 == s2 = unsafeMkSuited r1 r2
   | otherwise = unsafeMkOffsuit r1 r2
 
-instance Enum ShapedHand where
+instance Enum ShapedHole where
   toEnum num =
-    fromMaybe (error $ "Invalid ShapedHand enum: " <> show num)
+    fromMaybe (error $ "Invalid ShapedHole enum: " <> show num)
       . flip
         Data.IntMap.Strict.lookup
-        (Data.IntMap.Strict.fromList $ zip [1 ..] listShapedHands)
+        (Data.IntMap.Strict.fromList $ zip [1 ..] listShapedHoles)
       $ num
   fromEnum =
     fromJust
       . flip
         Data.Map.Strict.lookup
-        (Data.Map.Strict.fromList $ zip listShapedHands [1 ..])
+        (Data.Map.Strict.fromList $ zip listShapedHoles [1 ..])
 
-instance Bounded ShapedHand where
-  minBound = head listShapedHands
-  maxBound = last listShapedHands
+instance Bounded ShapedHole where
+  minBound = head listShapedHoles
+  maxBound = last listShapedHoles
 
-instance Pretty ShapedHand where
+instance Pretty ShapedHole where
   pretty (Offsuit r1 r2) = pretty r1 <> pretty r2 <> "o"
   pretty (Suited r1 r2) = pretty r1 <> pretty r2 <> "s"
   pretty (Pair r) = pretty r <> pretty r <> "p"
 
-instance ParsePretty ShapedHand where
-  parsePrettyP = label "ShapedHand" $ do
+instance ParsePretty ShapedHole where
+  parsePrettyP = label "ShapedHole" $ do
     r1 <- parsePrettyP @Rank
     r2 <- parsePrettyP @Rank
     let rs = (r1, r2)

--- a/src/Poker/Cards.hs
+++ b/src/Poker/Cards.hs
@@ -24,8 +24,8 @@ module Poker.Cards
     mkSuited,
     unsafeMkSuited,
     unsafeMkOffsuit,
-    listShapedHoles,
-    holeToShaped,
+    allShapedHoles,
+    holeToShapedHole,
     Deck,
     pattern Deck,
     freshDeck,
@@ -329,8 +329,8 @@ unsafeMkOffsuit r1 r2 =
   fromMaybe (terror $ "Cannot form offsuit hand from: " <> prettyText (r1, r2)) $
     mkOffsuit r1 r2
 
-listShapedHoles :: [ShapedHole]
-listShapedHoles = reverse $ do
+allShapedHoles :: [ShapedHole]
+allShapedHoles = reverse $ do
   rank1 <- enumerate
   rank2 <- enumerate
   return $ case compare rank1 rank2 of
@@ -360,8 +360,8 @@ shapedHoleToHoles = \case
     pure $ unsafeMkHole (Card r1 s) (Card r2 s)
 
 -- TODO needs tests
-holeToShaped :: Hole -> ShapedHole
-holeToShaped (Hole (Card r1 s1) (Card r2 s2))
+holeToShapedHole :: Hole -> ShapedHole
+holeToShapedHole (Hole (Card r1 s1) (Card r2 s2))
   | r1 == r2 = mkPair r1
   | s1 == s2 = unsafeMkSuited r1 r2
   | otherwise = unsafeMkOffsuit r1 r2
@@ -371,17 +371,17 @@ instance Enum ShapedHole where
     fromMaybe (error $ "Invalid ShapedHole enum: " <> show num)
       . flip
         Data.IntMap.Strict.lookup
-        (Data.IntMap.Strict.fromList $ zip [1 ..] listShapedHoles)
+        (Data.IntMap.Strict.fromList $ zip [1 ..] allShapedHoles)
       $ num
   fromEnum =
     fromJust
       . flip
         Data.Map.Strict.lookup
-        (Data.Map.Strict.fromList $ zip listShapedHoles [1 ..])
+        (Data.Map.Strict.fromList $ zip allShapedHoles [1 ..])
 
 instance Bounded ShapedHole where
-  minBound = head listShapedHoles
-  maxBound = last listShapedHoles
+  minBound = head allShapedHoles
+  maxBound = last allShapedHoles
 
 instance Pretty ShapedHole where
   pretty (Offsuit r1 r2) = pretty r1 <> pretty r2 <> "o"

--- a/src/Poker/Range.hs
+++ b/src/Poker/Range.hs
@@ -41,10 +41,10 @@ instance Semigroup Freq where
 -- | A simple wrapper around a Map that uses different instances
 -- for Semigroup. Normally, the Semigroup instance for Map is a left-biased Map merge.
 -- Range merges require Monoid values, and the Note that the internal Map is strict
--- >>> mempty @(Range Hand Freq)
+-- >>> mempty @(Range Hole Freq)
 -- Range {_range = fromList []}
 -- >>> import qualified Data.Text as T
--- >>> let left = fromList [(unsafeParsePretty @ShapedHand $ T.pack "55p", Freq 1 3)]
+-- >>> let left = fromList [(unsafeParsePretty @ShapedHole $ T.pack "55p", Freq 1 3)]
 -- >>> let right = fromList [(unsafeParsePretty $ T.pack"55p", Freq 10 32)]
 -- >>> left <> right
 -- Range {_range = fromList [(MkPair Five,Freq 11 35)]}
@@ -79,10 +79,10 @@ getDecisionFreqRange ::
 getDecisionFreqRange p (Range m) =
   Range $ Map.map (foldMap (\v -> Freq (bool 0 1 $ p v) 1)) m
 
-holdingRangeToShapedRange :: Monoid v => Range Hand v -> Range ShapedHand v
+holdingRangeToShapedRange :: Monoid v => Range Hole v -> Range ShapedHole v
 holdingRangeToShapedRange (Range r) =
-  Range $ Map.mapKeysWith (<>) handToShaped r
+  Range $ Map.mapKeysWith (<>) holeToShaped r
 
-addShaped :: Num a => a -> Hand -> Range ShapedHand a -> Range ShapedHand a
+addShaped :: Num a => a -> Hole -> Range ShapedHole a -> Range ShapedHole a
 addShaped n comb (Range r) =
-  Range $ Map.alter (pure . maybe 0 (+ n)) (handToShaped comb) r
+  Range $ Map.alter (pure . maybe 0 (+ n)) (holeToShaped comb) r

--- a/src/Poker/Range.hs
+++ b/src/Poker/Range.hs
@@ -81,8 +81,8 @@ getDecisionFreqRange p (Range m) =
 
 holdingRangeToShapedRange :: Monoid v => Range Hole v -> Range ShapedHole v
 holdingRangeToShapedRange (Range r) =
-  Range $ Map.mapKeysWith (<>) holeToShaped r
+  Range $ Map.mapKeysWith (<>) holeToShapedHole r
 
-addShaped :: Num a => a -> Hole -> Range ShapedHole a -> Range ShapedHole a
-addShaped n comb (Range r) =
-  Range $ Map.alter (pure . maybe 0 (+ n)) (holeToShaped comb) r
+addHoleToShapedRange :: Num a => a -> Hole -> Range ShapedHole a -> Range ShapedHole a
+addHoleToShapedRange n comb (Range r) =
+  Range $ Map.alter (pure . maybe 0 (+ n)) (holeToShapedHole comb) r

--- a/test/Test/Poker/Cards.hs
+++ b/test/Test/Poker/Cards.hs
@@ -114,15 +114,15 @@ spec_isoPrettyParseSuit = checkPrettyParseEnumIso @Suit "Suit"
 spec_isoPrettyParseCard :: SpecWith ()
 spec_isoPrettyParseCard = checkPrettyParseEnumIso @Card "Card"
 
-spec_isoPrettyParseHand :: SpecWith ()
-spec_isoPrettyParseHand = checkPrettyParseEnumIso @Hand "Hand"
+spec_isoPrettyParseHole :: SpecWith ()
+spec_isoPrettyParseHole = checkPrettyParseEnumIso @Hole "Hole"
 
-spec_isoPrettyParseShapedHand :: SpecWith ()
-spec_isoPrettyParseShapedHand = checkPrettyParseEnumIso @ShapedHand "ShapeHand"
+spec_isoPrettyParseShapedHole :: SpecWith ()
+spec_isoPrettyParseShapedHole = checkPrettyParseEnumIso @ShapedHole "ShapeHole"
 
 checkPrettyParseEnumIso ::
   forall a.
-  (Eq a, ParsePretty a, Pretty a, Enum a, Bounded a, Show a) =>
+  (Eq a, ParsePretty a, Enum a, Bounded a, Show a) =>
   String ->
   SpecWith ()
 checkPrettyParseEnumIso typeName =
@@ -132,28 +132,28 @@ checkPrettyParseEnumIso typeName =
     renderPrettyT = T.pack . show . pretty
     roundTrip = unsafeParsePretty . renderPrettyT
 
-spec_mkHand :: SpecWith ()
-spec_mkHand = do
+spec_mkHole :: SpecWith ()
+spec_mkHole = do
   let aceS = Card Ace Spade
   let aceD = Card Ace Diamond
   it "success" $
-    mkHand aceS aceD `shouldSatisfy` \case
-      Just (Hand c1 c2) | c1 == aceS, c2 == aceD -> True
+    mkHole aceS aceD `shouldSatisfy` \case
+      Just (Hole c1 c2) | c1 == aceS, c2 == aceD -> True
       _ -> False
-  it "fail" $ let c = Card Two Club in mkHand c c `shouldBe` Nothing
+  it "fail" $ let c = Card Two Club in mkHole c c `shouldBe` Nothing
   it "order doesn't matter" $
     allCardPairs
       `shouldSatisfy` all
-        (\(c1, c2) -> mkHand c1 c2 == mkHand c2 c1)
+        (\(c1, c2) -> mkHole c1 c2 == mkHole c2 c1)
   it "non-equal cards always succeed" $
     allCardPairs
       `shouldSatisfy` all
-        (\(c1, c2) -> c1 == c2 || isJust (mkHand c1 c2))
+        (\(c1, c2) -> c1 == c2 || isJust (mkHole c1 c2))
   where
     allCardPairs = [(c1, c2) | c1 <- enumerate, c2 <- enumerate]
 
-spec_mkShapedHand :: SpecWith ()
-spec_mkShapedHand = do
+spec_mkShapedHole :: SpecWith ()
+spec_mkShapedHole = do
   it "mkPair" $
     mkPair Ace `shouldSatisfy` \case
       Pair Ace -> True
@@ -185,19 +185,19 @@ spec_mkShapedHand = do
                       )
   it "mkOffsuit failure" $ mkOffsuit King King `shouldBe` Nothing
 
-spec_prettyShapedHand :: SpecWith ()
-spec_prettyShapedHand = do
+spec_prettyShapedHole :: SpecWith ()
+spec_prettyShapedHole = do
   it "Offsuit" $ show (pretty (mkOffsuit Ace Two)) `shouldBe` "A2o"
   it "Pair" $ show (pretty (mkPair Ace)) `shouldBe` "AAp"
   it "Suited" $ show (pretty (mkSuited Ace Two)) `shouldBe` "A2s"
 
 -- TODO Make sure test is total
--- TODO Make sure all ShapedHands are generated at the right frequency
+-- TODO Make sure all ShapedHoles are generated at the right frequency
 spec_handToShaped :: SpecWith ()
 spec_handToShaped = pure ()
 
-spec_shapedHandToHands :: SpecWith ()
-spec_shapedHandToHands = do
+spec_shapedHoleToHoles :: SpecWith ()
+spec_shapedHoleToHoles = do
   mkCase "Pair" "55p" ["5d5c", "5h5c", "5s5c", "5h5d", "5s5d", "5s5h"]
   mkCase "Suited" "AKs" ["AcKc", "AdKd", "AhKh", "AsKs"]
   mkCase "Offsuit" "QTo" offSuitExpected
@@ -219,7 +219,7 @@ spec_shapedHandToHands = do
       ]
     mkCase name combo expected =
       it name $
-        shapedHandToHands (unsafeParsePretty combo)
+        shapedHoleToHoles (unsafeParsePretty combo)
           `shouldBe` unsafeParsePretty
           <$> expected
 
@@ -243,17 +243,17 @@ spec_all = do
     it "Rank" $ allRanks `shouldBe` allRanksExpected
     it "Suit" $ allSuits `shouldBe` allSuitsExpected
     it "Card" $ allCards `shouldBe` allCardsExpected
-    it "number of Hands should be 1326" $
-      length (enumerate @Hand)
+    it "number of Holes should be 1326" $
+      length (enumerate @Hole)
         `shouldBe` 1326
-    it "number of Hands should be 1326" $
-      length (nub $ enumerate @Hand)
+    it "number of Holes should be 1326" $
+      length (nub $ enumerate @Hole)
         `shouldBe` 1326
-    it "number of ShapedHands should be 169" $
-      length (enumerate @ShapedHand)
+    it "number of ShapedHoles should be 169" $
+      length (enumerate @ShapedHole)
         `shouldBe` 169
-    it "number of unique ShapedHands should be 169" $
-      length (nub $ enumerate @ShapedHand)
+    it "number of unique ShapedHoles should be 169" $
+      length (nub $ enumerate @ShapedHole)
         `shouldBe` 169
   where
     allSuitsExpected = [Club, Diamond, Heart, Spade]


### PR DESCRIPTION
The new name is less likely to conflict with users'
libraries, which will often use the name Hand
for many different applications.